### PR TITLE
'fileEncoding' must be configured before any Outlet

### DIFF
--- a/org.eclipse.xtext.xdoc.generator/src/workflow/XDocGenerator.mwe2
+++ b/org.eclipse.xtext.xdoc.generator/src/workflow/XDocGenerator.mwe2
@@ -33,10 +33,10 @@ Workflow {
 
 	component = org.eclipse.xpand2.Generator {
 		expand = "templates::Template::main FOREACH doc"
+		fileEncoding = fileEncoding
 		outlet = {
 			path = targetDir
 		}
-		fileEncoding = fileEncoding
 		globalVar = {
 			name = "release"
 			value = "${release}"


### PR DESCRIPTION
In XDocGenerator.mwe2 the fileEncoding must be set before the outlet, otherwise, with the new Xpand you get

java.lang.IllegalStateException: 'fileEncoding' must be configured before any Outlet.
    at org.eclipse.xpand2.Generator.setFileEncoding(Generator.java:190)
    ... 56 more
